### PR TITLE
clean up gosec scan issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,5 +66,5 @@ go-coverage:
 			grep -v '/vendor/' | \
 			grep -v '/docs/' \
 		) > report.json)
-	gosec --quiet -fmt sonarqube -out gosec.json -no-fail ./...
+	gosec -fmt sonarqube -out gosec.json -no-fail ./...
 	sonar-scanner --debug || echo "Sonar scanner is not available"

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -44,7 +44,7 @@ func main() {
 	flag.StringVar(&eventOnParent, "parent-event", "ifpresent", "to also send status events on parent policy. options are: yes/no/ifpresent")
 	flag.StringVar(&defaultDuration, "default-duration", "672h", "The default minimum duration allowed for certificatepolicies to be compliant, must be in golang time format")
 
-	flag.Set("logtostderr", "true")
+	flag.Set("logtostderr", "true") /* #nosec G104 */
 
 	flag.Parse()
 
@@ -111,7 +111,7 @@ func main() {
 	// Initialize some variables
 	generatedClient := kubernetes.NewForConfigOrDie(mgr.GetConfig())
 	common.Initialize(generatedClient, cfg)
-	policyStatusHandler.Initialize(generatedClient, mgr, clusterName, namespace, eventOnParent, duration)
+	policyStatusHandler.Initialize(generatedClient, mgr, clusterName, namespace, eventOnParent, duration) /* #nosec G104 */
 	// PeriodicallyExecGRCPolicies is the go-routine that periodically checks the policies and does the needed work to make sure the desired state is achieved
 	go policyStatusHandler.PeriodicallyExecGRCPolicies(frequency)
 

--- a/pkg/controller/grcpolicy/grcpolicy_controller.go
+++ b/pkg/controller/grcpolicy/grcpolicy_controller.go
@@ -175,7 +175,7 @@ func (r *ReconcileGRCPolicy) Reconcile(request reconcile.Request) (reconcile.Res
 			}
 		}
 		instance.Status.CompliancyDetails = nil //reset CompliancyDetails
-		handleAddingPolicy(instance)
+		handleAddingPolicy(instance) /* #nosec G104 */
 	} else {
 		handleRemovingPolicy(instance)
 		// The object is being deleted


### PR DESCRIPTION
Address minor scan issues and remove quiet from Makefile for gosec.
Fixing security issues found in: https://github.com/open-cluster-management/backlog/issues/966

Minor issues are for error code checking but logging and retries already covers the error scenarios.