### PR TITLE
allow multiple policies per namespace by using different key in policy

### DIFF
--- a/pkg/controller/grcpolicy/grcpolicy_controller.go
+++ b/pkg/controller/grcpolicy/grcpolicy_controller.go
@@ -175,7 +175,7 @@ func (r *ReconcileGRCPolicy) Reconcile(request reconcile.Request) (reconcile.Res
 			}
 		}
 		instance.Status.CompliancyDetails = nil //reset CompliancyDetails
-		handleAddingPolicy(instance) /* #nosec G104 */
+		handleAddingPolicy(instance)            /* #nosec G104 */
 	} else {
 		handleRemovingPolicy(instance)
 		// The object is being deleted
@@ -230,7 +230,8 @@ func PeriodicallyExecGRCPolicies(freq uint) {
 		plcToUpdateMap = make(map[string]*policyv1alpha1.CertificatePolicy)
 
 		// Loops through all of the cert policies
-		for namespace, policy := range availablePolicies.PolicyMap {
+		for resource, policy := range availablePolicies.PolicyMap {
+			namespace := strings.Split(resource, "/")[0]
 			klog.V(4).Infof("Checking certificates in namespace %s defined in policy %s", namespace, policy.Name)
 			update, nonCompliant, list := certExpiration(policy, namespace)
 			if strings.ToLower(string(policy.Spec.RemediationAction)) == strings.ToLower(string(policyv1alpha1.Enforce)) {
@@ -472,7 +473,8 @@ func handleAddingPolicy(plc *policyv1alpha1.CertificatePolicy) error {
 	}
 	//clean up that policy from the existing namepsaces, in case the modification is in the namespace selector
 	for _, ns := range allNamespaces {
-		if policy, found := availablePolicies.GetObject(ns); found {
+		key := fmt.Sprintf("%s/%s", ns, plc.Name)
+		if policy, found := availablePolicies.GetObject(key); found {
 			if policy.Name == plc.Name {
 				availablePolicies.RemoveObject(ns)
 			}
@@ -480,7 +482,8 @@ func handleAddingPolicy(plc *policyv1alpha1.CertificatePolicy) error {
 	}
 	selectedNamespaces := common.GetSelectedNamespaces(plc.Spec.NamespaceSelector.Include, plc.Spec.NamespaceSelector.Exclude, allNamespaces)
 	for _, ns := range selectedNamespaces {
-		availablePolicies.AddObject(ns, plc)
+		key := fmt.Sprintf("%s/%s", ns, plc.Name)
+		availablePolicies.AddObject(key, plc)
 	}
 	return err
 }


### PR DESCRIPTION
Issue https://github.com/open-cluster-management/backlog/issues/1905 shows that multiple policies looking for expired certs in the same namespace causes a conflict which this PR will resolve.