### PR TITLE
remove the finalizer so policy deletes can happen without the running…

### DIFF
--- a/pkg/controller/grcpolicy/grcpolicy_controller.go
+++ b/pkg/controller/grcpolicy/grcpolicy_controller.go
@@ -155,17 +155,9 @@ func (r *ReconcileGRCPolicy) Reconcile(request reconcile.Request) (reconcile.Res
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}
-	// name of our mcm custom finalizer
-	myFinalizerName := Finalizer
 
 	if instance.ObjectMeta.DeletionTimestamp.IsZero() {
 		updateNeeded := false
-		// The object is not being deleted, so if it might not have our finalizer,
-		// then lets add the finalizer and update the object.
-		if !containsString(instance.ObjectMeta.Finalizers, myFinalizerName) {
-			instance.ObjectMeta.Finalizers = append(instance.ObjectMeta.Finalizers, myFinalizerName)
-			updateNeeded = true
-		}
 		if !ensureDefaultLabel(instance) {
 			updateNeeded = true
 		}
@@ -175,25 +167,10 @@ func (r *ReconcileGRCPolicy) Reconcile(request reconcile.Request) (reconcile.Res
 			}
 		}
 		instance.Status.CompliancyDetails = nil //reset CompliancyDetails
-		handleAddingPolicy(instance) /* #nosec G104 */
+		handleAddingPolicy(instance)            /* #nosec G104 */
 	} else {
 		handleRemovingPolicy(instance)
 		// The object is being deleted
-		if containsString(instance.ObjectMeta.Finalizers, myFinalizerName) {
-			// our finalizer is present, so lets handle our external dependency
-			if err := r.deleteExternalDependency(instance); err != nil {
-				// if fail to delete the external dependency here, return with error
-				// so that it can be retried
-				return reconcile.Result{}, err
-			}
-
-			// remove our finalizer from the list and update it.
-			instance.ObjectMeta.Finalizers = removeString(instance.ObjectMeta.Finalizers, myFinalizerName)
-			if err := r.Update(context.Background(), instance); err != nil {
-				return reconcile.Result{Requeue: true}, nil
-			}
-		}
-		// Our finalizer has finished, so the reconciler can do nothing.
 		return reconcile.Result{}, nil
 	}
 	klog.V(3).Infof("reason: successful processing, subject: policy/%v, namespace: %v, according to policy: %v, additional-info: none\n", instance.Name, instance.Namespace, instance.Name)


### PR DESCRIPTION
This will remove the finalizer in the policy controller.  The cluster detach currently cleans up the pods and the policies at the same time.  The finalizer in the policy requires the pod to be running but since the finalizer currently doesn't do anything we can eliminate this dependency.

Fix for https://github.com/open-cluster-management/backlog/issues/1930