### PR TITLE
undo change to sonar properties that limited tests

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,8 +1,8 @@
 sonar.projectKey=open-cluster-management_cert-policy-controller
 sonar.projectName=cert-policy-controller
-sonar.sources=pkg
+sonar.sources=.
 sonar.exclusions=**/*_test.go,**/*_generated*.go,**/*_generated/**,**/vendor/**,**/vbh/**
-sonar.tests=pkg
+sonar.tests=.
 sonar.test.inclusions=**/*_test.go
 sonar.test.exclusions=**/*_generated*.go,**/*_generated/**,**/vendor/**,**/vbh/**
 sonar.go.tests.reportPaths=report.json


### PR DESCRIPTION
The update to the sonar properties seems to have prevented some tests from running in travis. 