### PR TITLE
do not create latest-dev image unless we're on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ jobs:
           make component/build
           make component/push
           make security/scans
-        - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then 
+        - if [ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master" ]; then 
             export COMPONENT_NEWTAG="latest-dev";
             make component/tag;
             export COMPONENT_VERSION="latest";


### PR DESCRIPTION
Only create latest-dev if we're on the master branch. 
The e2e is having a problem because the latest-dev image is tagged from the build of an older branch.