### PR TITLE
this is to address an end to end test issue and does not impact 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ jobs:
           make component/build
           make component/push
           make security/scans
-        - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then 
+        - if [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_BRANCH" == "master" ]; then
             export COMPONENT_NEWTAG="latest-dev";
             make component/tag;
             export COMPONENT_VERSION="latest";


### PR DESCRIPTION
We use an image tagged as `latest-dev` for e2e testing.  Accidentally the tag gets created by 2.0 builds so this change will stop 2.0 builds from creating an image with that tag.  Right now each time 2.0 rebuilds this component that tag gets updated and our e2e tests fail.

I wrote an issue since it's going into 2.0: https://github.com/open-cluster-management/backlog/issues/4756