### PR TITLE
add more status update checks

### DIFF
--- a/pkg/controller/certificatepolicy/certificatepolicy_controller.go
+++ b/pkg/controller/certificatepolicy/certificatepolicy_controller.go
@@ -485,6 +485,12 @@ func addViolationCount(plc *policyv1.CertificatePolicy, message string, count ui
 	if plc.Status.CompliancyDetails[namespace].NonCompliantCertificates != count {
 		changed = true
 	}
+	if count > 0 && plc.Status.ComplianceState == policyv1.Compliant {
+		changed = true
+	}
+	if message != plc.Status.CompliancyDetails[namespace].Message {
+		changed = true
+	}
 
 	plc.Status.CompliancyDetails[namespace] = policyv1.CompliancyDetails{
 		NonCompliantCertificates:     count,


### PR DESCRIPTION
The end to end test isn't working well.  The only scenario I have manually seen that I think is an issue is sometimes the transition from 2 expired certificates to 1 expired certificate is not getting updated (no parent update event is sent).  