### PR TITLE
Remove a duplicate lease for leader election

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -28,5 +28,3 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "cert-policy-controller"
-          args:
-            - "--enable-lease=true"


### PR DESCRIPTION
After upgrading the operator-sdk, the manual leader election via a lease
was not removed. This is handled automatically now in the `NewManager`
function in the "sigs.k8s.io/controller-runtime" package.