### PR TITLE
Remove unnecessary permissions for pods

### DIFF
--- a/controllers/certificatepolicy_controller.go
+++ b/controllers/certificatepolicy_controller.go
@@ -90,8 +90,7 @@ type Reconciler struct {
 //+kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=certificatepolicies/finalizers,verbs=update
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups="",resources=namespaces,verbs=list
-//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
-//+kubebuilder:rbac:groups="",resources=pods,verbs=get;list
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -64,18 +64,10 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - ""
-  resources:
   - secrets
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - policy.open-cluster-management.io
   resources:

--- a/deploy/rbac/role.yaml
+++ b/deploy/rbac/role.yaml
@@ -22,18 +22,10 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - ""
-  resources:
   - secrets
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - policy.open-cluster-management.io
   resources:


### PR DESCRIPTION
Refs:
 - https://github.com/open-cluster-management/backlog/issues/17918

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>

Note that issue 17918 questioned whether this controller needed access to secrets, and it does need that access: that's where certificates are stored.