### PR TITLE
Synchronize logging levels with libraries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	k8s.io/api v0.23.3
 	k8s.io/apimachinery v0.23.3
 	k8s.io/client-go v12.0.0+incompatible
+	k8s.io/klog/v2 v2.40.1
 	open-cluster-management.io/addon-framework v0.2.0
 	sigs.k8s.io/controller-runtime v0.11.1
 )
@@ -68,7 +69,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/apiextensions-apiserver v0.23.3 // indirect
 	k8s.io/component-base v0.23.3 // indirect
-	k8s.io/klog/v2 v2.40.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220124234850-424119656bbf // indirect
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	open-cluster-management.io/multicloud-operators-subscription v0.6.0 // indirect


### PR DESCRIPTION
Previously, dependencies using `klog` were not able to have their log
levels adjusted. Now, they can be adjusted through the `v` flag, and
that level will override the `zap-log-level` if given. Additionally,
klog will send logs through the zap logr, which will make them all look
the same (JSON vs console).

Refs:
 - https://github.com/stolostron/backlog/issues/19030

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>