### PR TITLE
Rename the module name to match upstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,6 @@ REGISTRY ?= quay.io/stolostron
 TAG ?= latest
 IMAGE_NAME_AND_VERSION ?= $(REGISTRY)/$(IMG)
 
-# Github host to use for checking the source tree;
-# Override this variable ue with your own value if you're working on forked repo.
-GIT_HOST ?= github.com/stolostron
-
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 define go-get-tool
@@ -238,7 +234,7 @@ e2e-test-coverage: E2E_TEST_ARGS = --json-report=report_e2e.json --output-dir=.
 e2e-test-coverage: e2e-test
 
 e2e-build-instrumented:
-	go test -covermode=atomic -coverpkg=$(GIT_HOST)/$(IMG)/... -c -tags e2e ./ -o build/_output/bin/$(IMG)-instrumented
+	go test -covermode=atomic -coverpkg=$(shell cat go.mod | head -1 | cut -d ' ' -f 2)/... -c -tags e2e ./ -o build/_output/bin/$(IMG)-instrumented
 
 e2e-run-instrumented:
 	WATCH_NAMESPACE="$(WATCH_NAMESPACE)" ./build/_output/bin/$(IMG)-instrumented -test.run "^TestRunMain$$" -test.coverprofile=coverage_e2e.out &>/dev/null &

--- a/PROJECT
+++ b/PROJECT
@@ -13,6 +13,6 @@ resources:
   domain: open-cluster-management.io
   group: policy
   kind: CertificatePolicy
-  path: github.com/stolostron/cert-policy-controller/api/v1
+  path: open-cluster-management.io/cert-policy-controller/api/v1
   version: v1
 version: "3"

--- a/build/common/config/.golangci.yml
+++ b/build/common/config/.golangci.yml
@@ -68,7 +68,7 @@ linters-settings:
     # report about shadowed variables
     check-shadowing: false
   gci:
-    local-prefixes: github.com/stolostron/cert-policy-controller
+    local-prefixes: open-cluster-management.io/cert-policy-controller
   golint:
     # minimal confidence for issues, default is 0.8
     min-confidence: 0.0

--- a/controllers/certificatepolicy_controller.go
+++ b/controllers/certificatepolicy_controller.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 	"time"
 
-	extpolicyv1 "github.com/stolostron/governance-policy-propagator/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,15 +24,16 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
+	extpolicyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	policyv1 "github.com/stolostron/cert-policy-controller/api/v1"
-	"github.com/stolostron/cert-policy-controller/controllers/util"
-	"github.com/stolostron/cert-policy-controller/pkg/common"
+	policyv1 "open-cluster-management.io/cert-policy-controller/api/v1"
+	"open-cluster-management.io/cert-policy-controller/controllers/util"
+	"open-cluster-management.io/cert-policy-controller/pkg/common"
 )
 
 const (

--- a/controllers/certificatepolicy_controller_test.go
+++ b/controllers/certificatepolicy_controller_test.go
@@ -34,8 +34,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	policiesv1 "github.com/stolostron/cert-policy-controller/api/v1"
-	"github.com/stolostron/cert-policy-controller/pkg/common"
+	policiesv1 "open-cluster-management.io/cert-policy-controller/api/v1"
+	"open-cluster-management.io/cert-policy-controller/pkg/common"
 )
 
 func TestReconcile(t *testing.T) {

--- a/controllers/certificatepolicy_utils.go
+++ b/controllers/certificatepolicy_utils.go
@@ -13,7 +13,7 @@ import (
 	"sort"
 	"time"
 
-	policyv1 "github.com/stolostron/cert-policy-controller/api/v1"
+	policyv1 "open-cluster-management.io/cert-policy-controller/api/v1"
 )
 
 var format = "%s; %s"

--- a/controllers/certificatepolicy_utils_test.go
+++ b/controllers/certificatepolicy_utils_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	policiesv1 "github.com/stolostron/cert-policy-controller/api/v1"
+	policiesv1 "open-cluster-management.io/cert-policy-controller/api/v1"
 )
 
 func TestConvertPolicyStatusToString(t *testing.T) {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -30,7 +30,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	policyv1 "github.com/stolostron/cert-policy-controller/api/v1"
+	policyv1 "open-cluster-management.io/cert-policy-controller/api/v1"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/stolostron/cert-policy-controller
+module open-cluster-management.io/cert-policy-controller
 
 go 1.17
 
@@ -8,13 +8,13 @@ require (
 	github.com/onsi/gomega v1.18.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stolostron/go-log-utils v0.1.0
-	github.com/stolostron/governance-policy-propagator v0.0.0-20220217025800-1a04477f8f38
 	github.com/stretchr/testify v1.7.0
 	k8s.io/api v0.23.3
 	k8s.io/apimachinery v0.23.3
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/klog/v2 v2.40.1
 	open-cluster-management.io/addon-framework v0.2.0
+	open-cluster-management.io/governance-policy-propagator v0.0.0
 	sigs.k8s.io/controller-runtime v0.11.1
 )
 
@@ -81,4 +81,5 @@ require (
 replace (
 	golang.org/x/crypto => golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // CVE-2021-43565
 	k8s.io/client-go => k8s.io/client-go v0.23.3
+	open-cluster-management.io/governance-policy-propagator => github.com/stolostron/governance-policy-propagator v0.0.0-20220427184903-387712d230ee
 )

--- a/go.sum
+++ b/go.sum
@@ -1130,8 +1130,8 @@ github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag
 github.com/stolostron/go-log-utils v0.1.0 h1:YRi84JogWKHCfrif46m/4rep+ucsc80c9667FzaBbTA=
 github.com/stolostron/go-log-utils v0.1.0/go.mod h1:2Uc5mbuLvSFpoXFFEKRTEFOlR7nqGVMu9mbU+FIttTI=
 github.com/stolostron/go-template-utils/v2 v2.2.2/go.mod h1:z4d9KZkkW5jAHns3bafVTmab+eq/jVsoFRYWbH37Qu4=
-github.com/stolostron/governance-policy-propagator v0.0.0-20220217025800-1a04477f8f38 h1:a3mDbBUE0eVXdzv0IIsz6/48F7Ru6LxwPduryJU7UXQ=
-github.com/stolostron/governance-policy-propagator v0.0.0-20220217025800-1a04477f8f38/go.mod h1:8lcjUP24z9gIZ1nCydZyOxIqz6CpVDtVt5KPAlsi+tY=
+github.com/stolostron/governance-policy-propagator v0.0.0-20220427184903-387712d230ee h1:LgW1jklD9sFTs2APhyUMeFf/2TMI+SC+uJfCSZ/mtDs=
+github.com/stolostron/governance-policy-propagator v0.0.0-20220427184903-387712d230ee/go.mod h1:yMzjFPXvRoNHSY3ggD9d8ffukUVDGCHhMxAvj3q5EEE=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=
@@ -2004,8 +2004,8 @@ open-cluster-management.io/api v0.0.0-20210607023841-cd164385e2bb/go.mod h1:9qiA
 open-cluster-management.io/api v0.0.0-20210629235044-d779373b7f7d/go.mod h1:9qiA5h/8kvPQnJEOlAPHVjRO9a1jCmDhGzvgMBvXEaE=
 open-cluster-management.io/api v0.5.1-0.20211109002058-9676c7a1e606/go.mod h1:9qiA5h/8kvPQnJEOlAPHVjRO9a1jCmDhGzvgMBvXEaE=
 open-cluster-management.io/api v0.5.1-0.20220112073018-2d280a97a052/go.mod h1:0IUTh8J+p4pv1THh1r9oO0luX9Z1FLDEAmvzW09qC0o=
-open-cluster-management.io/api v0.6.0 h1:PzR1G/d9YmwL742lgJgFgsEJs6i8Zg05pdIhK/iLZV4=
-open-cluster-management.io/api v0.6.0/go.mod h1:0IUTh8J+p4pv1THh1r9oO0luX9Z1FLDEAmvzW09qC0o=
+open-cluster-management.io/api v0.6.1-0.20220208144021-3297cac74dc5 h1:0Zn4+5qfXTHCjoa7pg8+fI/Gebr4bQDHWR+d1XPa47c=
+open-cluster-management.io/api v0.6.1-0.20220208144021-3297cac74dc5/go.mod h1:0IUTh8J+p4pv1THh1r9oO0luX9Z1FLDEAmvzW09qC0o=
 open-cluster-management.io/multicloud-operators-channel v0.5.1-0.20211122200432-da1610291798/go.mod h1:ELKJ1LHadEYbYHEeWrZXC8zAHrzXzzKJRtp/7D1WlmU=
 open-cluster-management.io/multicloud-operators-subscription v0.6.0 h1:0WKplR0cLBXy+qkqt/Scd3eTcEOno0OvzAXzAhe9nLQ=
 open-cluster-management.io/multicloud-operators-subscription v0.6.0/go.mod h1:riyPTC500zbKxVw3KT91yKNlpPxTdWDnUpOQ9xcLmXc=

--- a/main.go
+++ b/main.go
@@ -18,11 +18,11 @@ import (
 	"github.com/go-logr/zapr"
 	"github.com/spf13/pflag"
 	"github.com/stolostron/go-log-utils/zaputil"
-	extpolicyv1 "github.com/stolostron/governance-policy-propagator/api/v1"
 	apiRuntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog/v2"
 	"open-cluster-management.io/addon-framework/pkg/lease"
+	extpolicyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 
 	// Import all Kubernetes client auth plugins to ensure that exec-entrypoint and run can make use of them.
 	"k8s.io/client-go/kubernetes"
@@ -33,10 +33,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
-	policyv1 "github.com/stolostron/cert-policy-controller/api/v1"
-	controllers "github.com/stolostron/cert-policy-controller/controllers"
-	"github.com/stolostron/cert-policy-controller/pkg/common"
-	"github.com/stolostron/cert-policy-controller/version"
+	policyv1 "open-cluster-management.io/cert-policy-controller/api/v1"
+	controllers "open-cluster-management.io/cert-policy-controller/controllers"
+	"open-cluster-management.io/cert-policy-controller/pkg/common"
+	"open-cluster-management.io/cert-policy-controller/version"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/pkg/common/common_suite_test.go
+++ b/pkg/common/common_suite_test.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	policyv1 "github.com/stolostron/cert-policy-controller/api/v1"
+	policyv1 "open-cluster-management.io/cert-policy-controller/api/v1"
 )
 
 var cfg *rest.Config

--- a/pkg/common/namespace_selection.go
+++ b/pkg/common/namespace_selection.go
@@ -12,7 +12,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	policyv1 "github.com/stolostron/cert-policy-controller/api/v1"
+	policyv1 "open-cluster-management.io/cert-policy-controller/api/v1"
 )
 
 //=================================================================

--- a/pkg/common/namespace_selection_test.go
+++ b/pkg/common/namespace_selection_test.go
@@ -34,7 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	policiesv1 "github.com/stolostron/cert-policy-controller/api/v1"
+	policiesv1 "open-cluster-management.io/cert-policy-controller/api/v1"
 )
 
 var c client.Client

--- a/pkg/common/pattern_util.go
+++ b/pkg/common/pattern_util.go
@@ -10,7 +10,7 @@ package common
 import (
 	"strings"
 
-	policyv1 "github.com/stolostron/cert-policy-controller/api/v1"
+	policyv1 "open-cluster-management.io/cert-policy-controller/api/v1"
 )
 
 // FindPattern finds patterns.

--- a/pkg/common/synced_map_utils.go
+++ b/pkg/common/synced_map_utils.go
@@ -10,7 +10,7 @@ package common
 import (
 	"sync"
 
-	policyv1 "github.com/stolostron/cert-policy-controller/api/v1"
+	policyv1 "open-cluster-management.io/cert-policy-controller/api/v1"
 )
 
 // SyncedPolicyMap a thread safe map.

--- a/pkg/common/synced_map_utils_test.go
+++ b/pkg/common/synced_map_utils_test.go
@@ -22,7 +22,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	policiesv1 "github.com/stolostron/cert-policy-controller/api/v1"
+	policiesv1 "open-cluster-management.io/cert-policy-controller/api/v1"
 )
 
 /*


### PR DESCRIPTION
This will significantly reduce merge conflicts when syncing upstream to
Stolostron. It will also reduce the overhead of maintaining the
difference.

Related:
https://github.com/stolostron/backlog/issues/21790