### PR TITLE
Implement `go install`

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -50,7 +50,6 @@ jobs:
 
     - name: Verify format
       run: |
-        make fmt-dependencies
         make fmt
         git diff --exit-code
         make lint
@@ -62,7 +61,6 @@ jobs:
 
     - name: Unit and Integration Tests
       run: |
-        make test-dependencies
         make test
 
     - name: Create K8s KinD Cluster - ${{ matrix.kind }}
@@ -71,18 +69,11 @@ jobs:
       run: |
         make kind-bootstrap-cluster-dev
 
-    - name: Start instrumented controller
-      run: |
-        make e2e-build-instrumented
-        make e2e-run-instrumented
-
     - name: E2E Tests
       run: |
         export GOPATH=$(go env GOPATH)
-        make e2e-dependencies
         make e2e-test-coverage \
           || true # Remove this line once E2E tests are implemented!!!
-        make e2e-stop-instrumented
 
     - name: Test Coverage Verification
       if: ${{ github.event_name == 'pull_request' }}

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,14 @@ include build/common/Makefile.common.mk
 .PHONY: all
 all: test
 
+.PHONY: clean
+clean:
+	-rm bin/*
+	-rm build/_output/bin/*
+	-rm coverage*.out
+	-rm kubeconfig_managed
+	-rm -r vendor/
+
 ############################################################
 # build, run
 ############################################################

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,6 @@ kustomize: ## Download kustomize locally if necessary.
 # unit test
 ############################################################
 GOSEC = $(shell pwd)/bin/gosec
-GOSEC_VERSION = 2.9.6
 KUBEBUILDER_DIR = /usr/local/kubebuilder/bin
 KBVERSION = 3.2.0
 K8S_VERSION = 1.21.2
@@ -192,7 +191,7 @@ gosec:
 	$(call go-get-tool,github.com/securego/gosec/v2/cmd/gosec@v2.9.6)
 
 .PHONY: gosec-scan
-gosec-scan: $(GOSEC)
+gosec-scan: gosec
 	$(GOSEC) -fmt sonarqube -out gosec.json -no-fail -exclude-dir=.go ./...
 
 ############################################################

--- a/Makefile
+++ b/Makefile
@@ -260,19 +260,19 @@ e2e-dependencies:
 	$(call go-get-tool,github.com/onsi/ginkgo/v2/ginkgo@$(shell awk '/github.com\/onsi\/ginkgo\/v2/ {print $$2}' go.mod))
 
 .PHONY: e2e-test
-e2e-test:
+e2e-test: e2e-dependencies
 	$(GINKGO) -v --fail-fast --slow-spec-threshold=10s $(E2E_TEST_ARGS) test/e2e
 
 .PHONY: e2e-test-coverage
 e2e-test-coverage: E2E_TEST_ARGS = --json-report=report_e2e.json --output-dir=.
-e2e-test-coverage: e2e-test
+e2e-test-coverage: e2e-run-instrumented e2e-test e2e-stop-instrumented
 
 .PHONY: e2e-build-instrumented
 e2e-build-instrumented:
 	go test -covermode=atomic -coverpkg=$(shell cat go.mod | head -1 | cut -d ' ' -f 2)/... -c -tags e2e ./ -o build/_output/bin/$(IMG)-instrumented
 
 .PHONY: e2e-run-instrumented
-e2e-run-instrumented:
+e2e-run-instrumented: e2e-build-instrumented
 	WATCH_NAMESPACE="$(WATCH_NAMESPACE)" ./build/_output/bin/$(IMG)-instrumented -test.run "^TestRunMain$$" -test.coverprofile=coverage_e2e.out &>/dev/null &
 
 .PHONY: e2e-stop-instrumented

--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,6 @@ ifneq ($(KIND_VERSION), latest)
 else
 	KIND_ARGS =
 endif
-# Fetch Ginkgo/Gomega versions from go.mod
-GINKGO_VERSION := $(shell awk '/github.com\/onsi\/ginkgo\/v2/ {print $$2}' go.mod)
-GOMEGA_VERSION := $(shell awk '/github.com\/onsi\/gomega/ {print $$2}' go.mod)
 # Test coverage threshold
 export COVERAGE_MIN ?= 65
 
@@ -179,6 +176,7 @@ gosec-scan: $(GOSEC)
 ############################################################
 # e2e test (using KinD clusters)
 ############################################################
+GINKGO = $(shell pwd)/bin/ginkgo
 
 .PHONY: kind-bootstrap-cluster
 kind-bootstrap-cluster: kind-create-cluster kind-deploy-controller install-resources
@@ -220,7 +218,7 @@ e2e-dependencies:
 	$(call go-get-tool,github.com/onsi/ginkgo/v2/ginkgo@$(shell awk '/github.com\/onsi\/ginkgo\/v2/ {print $$2}' go.mod))
 
 e2e-test:
-	$(GOPATH)/bin/ginkgo -v --fail-fast --slow-spec-threshold=10s $(E2E_TEST_ARGS) test/e2e
+	$(GINKGO) -v --fail-fast --slow-spec-threshold=10s $(E2E_TEST_ARGS) test/e2e
 
 e2e-test-coverage: E2E_TEST_ARGS = --json-report=report_e2e.json --output-dir=.
 e2e-test-coverage: e2e-test

--- a/Makefile
+++ b/Makefile
@@ -43,18 +43,11 @@ REGISTRY ?= quay.io/stolostron
 TAG ?= latest
 IMAGE_NAME_AND_VERSION ?= $(REGISTRY)/$(IMG)
 
-# go-get-tool will 'go get' any package $2 and install it to $1.
-PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+# go-get-tool will 'go install' any package $1 and install it to LOCAL_BIN.
 define go-get-tool
-@[ -f $(1) ] || { \
-set -e ;\
-TMP_DIR=$$(mktemp -d) ;\
-cd $$TMP_DIR ;\
-go mod init tmp ;\
-echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
-rm -rf $$TMP_DIR ;\
-}
+@set -e ;\
+echo "Checking installation of $(1)" ;\
+GOBIN=$(LOCAL_BIN) go install $(1)
 endef
 
 include build/common/Makefile.common.mk
@@ -108,13 +101,13 @@ create-ns:
 
 # Lint code
 lint-dependencies:
-	$(call go-get-tool,$(PWD)/bin/golangci-lint,github.com/golangci/golangci-lint/cmd/golangci-lint@v1.41.1)
+	$(call go-get-tool,github.com/golangci/golangci-lint/cmd/golangci-lint@v1.41.1)
 
 lint: lint-dependencies lint-all
 
 fmt-dependencies:
-	$(call go-get-tool,$(PWD)/bin/gci,github.com/daixiang0/gci@v0.2.9)
-	$(call go-get-tool,$(PWD)/bin/gofumpt,mvdan.cc/gofumpt@v0.2.0)
+	$(call go-get-tool,github.com/daixiang0/gci@v0.2.9)
+	$(call go-get-tool,mvdan.cc/gofumpt@v0.2.0)
 
 fmt: fmt-dependencies
 	find . -not \( -path "./.go" -prune \) -name "*.go" | xargs gofmt -s -w
@@ -144,11 +137,11 @@ generate-operator-yaml: kustomize manifests
 
 .PHONY: controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.1)
+	$(call go-get-tool,sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.1)
 
 .PHONY: kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+	$(call go-get-tool,sigs.k8s.io/kustomize/kustomize/v4@v4.5.4)
 
 ############################################################
 # unit test
@@ -176,9 +169,9 @@ test-dependencies:
 	sudo chmod +x $(KUBEBUILDER_DIR)/kubebuilder
 	curl -L "https://go.kubebuilder.io/test-tools/$(K8S_VERSION)/$(GOOS)/$(GOARCH)" | sudo tar xz --strip-components=2 -C $(KUBEBUILDER_DIR)/
 
-$(GOSEC):
-	curl -L https://github.com/securego/gosec/releases/download/v$(GOSEC_VERSION)/gosec_$(GOSEC_VERSION)_$(GOOS)_$(GOARCH).tar.gz | tar -xz -C /tmp/
-	sudo mv /tmp/gosec $(GOSEC)
+.PHONY: gosec
+gosec:
+	$(call go-get-tool,github.com/securego/gosec/v2/cmd/gosec@v2.9.6)
 
 gosec-scan: $(GOSEC)
 	$(GOSEC) -fmt sonarqube -out gosec.json -no-fail -exclude-dir=.go ./...
@@ -224,8 +217,7 @@ install-resources:
 	kubectl create ns $(WATCH_NAMESPACE)
 
 e2e-dependencies:
-	go get github.com/onsi/ginkgo/v2/ginkgo@$(GINKGO_VERSION)
-	go get github.com/onsi/gomega/...@$(GOMEGA_VERSION)
+	$(call go-get-tool,github.com/onsi/ginkgo/v2/ginkgo@$(shell awk '/github.com\/onsi\/ginkgo\/v2/ {print $$2}' go.mod))
 
 e2e-test:
 	$(GOPATH)/bin/ginkgo -v --fail-fast --slow-spec-threshold=10s $(E2E_TEST_ARGS) test/e2e
@@ -255,7 +247,7 @@ e2e-debug:
 ############################################################
 GOCOVMERGE = $(shell pwd)/bin/gocovmerge
 coverage-dependencies:
-	$(call go-get-tool,$(GOCOVMERGE),github.com/wadey/gocovmerge)
+	$(call go-get-tool,github.com/wadey/gocovmerge@v0.0.0-20160331181800-b5bfa59ec0ad)
 
 COVERAGE_FILE = coverage.out
 coverage-merge: coverage-dependencies

--- a/deploy/crds/policy.open-cluster-management.io_certificatepolicies.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_certificatepolicies.yaml
@@ -20,10 +20,14 @@ spec:
         description: CertificatePolicy is the Schema for the certificatepolicies API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -31,11 +35,15 @@ spec:
             description: CertificatePolicySpec defines the desired state of CertificatePolicy
             properties:
               allowedSANPattern:
-                description: A pattern that must match any defined SAN entries in the certificate for the certificate to be compliant.  Golang's regexp syntax only.
+                description: A pattern that must match any defined SAN entries in
+                  the certificate for the certificate to be compliant.  Golang's regexp
+                  syntax only.
                 minLength: 1
                 type: string
               disallowedSANPattern:
-                description: A pattern that must not match any defined SAN entries in the certificate for the certificate to be compliant. Golang's regexp syntax only.
+                description: A pattern that must not match any defined SAN entries
+                  in the certificate for the certificate to be compliant. Golang's
+                  regexp syntax only.
                 minLength: 1
                 type: string
               labelSelector:
@@ -44,19 +52,23 @@ spec:
                   type: string
                 type: object
               maximumCADuration:
-                description: Maximum CA duration for a signing certificate, longer duration is considered non-compliant. Golang's time units only.
+                description: Maximum CA duration for a signing certificate, longer
+                  duration is considered non-compliant. Golang's time units only.
                 pattern: ^(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))+$
                 type: string
               maximumDuration:
-                description: Maximum duration for a certificate, longer duration is considered non-compliant. Golang's time units only.
+                description: Maximum duration for a certificate, longer duration is
+                  considered non-compliant. Golang's time units only.
                 pattern: ^(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))+$
                 type: string
               minimumCADuration:
-                description: Minimum CA duration before a signing certificate expires that it is considered non-compliant. Golang's time units only.
+                description: Minimum CA duration before a signing certificate expires
+                  that it is considered non-compliant. Golang's time units only.
                 pattern: ^(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))+$
                 type: string
               minimumDuration:
-                description: Minimum duration before a certificate expires that it is considered non-compliant. Golang's time units only.
+                description: Minimum duration before a certificate expires that it
+                  is considered non-compliant. Golang's time units only.
                 pattern: ^(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))+$
                 type: string
               namespaceSelector:
@@ -99,7 +111,8 @@ spec:
             properties:
               compliancyDetails:
                 additionalProperties:
-                  description: CompliancyDetails defines the all the details related to whether or not the policy is compliant
+                  description: CompliancyDetails defines the all the details related
+                    to whether or not the policy is compliant
                   properties:
                     message:
                       type: string
@@ -107,18 +120,25 @@ spec:
                       type: integer
                     nonCompliantCertificatesList:
                       additionalProperties:
-                        description: Cert contains its related secret and when it expires
+                        description: Cert contains its related secret and when it
+                          expires
                         properties:
                           ca:
                             type: boolean
                           duration:
-                            description: A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.
+                            description: A Duration represents the elapsed time between
+                              two instants as an int64 nanosecond count. The representation
+                              limits the largest representable duration to approximately
+                              290 years.
                             format: int64
                             type: integer
                           expiration:
                             type: string
                           expiry:
-                            description: A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.
+                            description: A Duration represents the elapsed time between
+                              two instants as an int64 nanosecond count. The representation
+                              limits the largest representable duration to approximately
+                              290 years.
                             format: int64
                             type: integer
                           sans:


### PR DESCRIPTION
Addresses:
- https://github.com/stolostron/backlog/issues/21024

I also removed logic to check whether the file exists since it appears to be a fairly quick check for Go to see that it's installed and then we also won't have to worry about whether we have the correct version on our system.

I'm also curious whether `go get github.com/onsi/gomega/...` is even necessary in the `e2e-dependencies` target. I think we only need the binary since `gomega` is already in `go.mod`? I might try removing it if this initial commit works.