### PR TITLE
Switch leader election default

### DIFF
--- a/main.go
+++ b/main.go
@@ -223,6 +223,10 @@ func main() {
 		// If legacyLeaderElection is enabled, then that means the lease API is not available.
 		// In this case, use the legacy leader election method of a ConfigMap.
 		options.LeaderElectionResourceLock = "configmaps"
+	} else {
+		// use the leases leader election by default for controller-runtime 0.11 instead of
+		// the default of configmapsleases (leases is the new default in 0.12)
+		options.LeaderElectionResourceLock = "leases"
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)


### PR DESCRIPTION
Current default is configmapsleases which is no longer preferred.
Using leases instead.

Refs:
 - https://github.com/stolostron/backlog/issues/19110

Signed-off-by: Gus Parvin <gparvin@redhat.com>