### PR TITLE
Remove generation changed predicate filter

### DIFF
--- a/controllers/certificatepolicy_controller.go
+++ b/controllers/certificatepolicy_controller.go
@@ -28,7 +28,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	policyv1 "open-cluster-management.io/cert-policy-controller/api/v1"
@@ -916,6 +915,5 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(ControllerName).
 		For(&policyv1.CertificatePolicy{}).
-		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(r)
 }


### PR DESCRIPTION
This allows the template-sync controller to trigger a new compliance
event to be emitted by deleting the complianceState from the status.

Refs:
 - https://github.com/stolostron/backlog/issues/24750

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>