### PR TITLE
Add `policy-type=template` label to CRD

### DIFF
--- a/deploy/crds/kustomize/kustomization.yaml
+++ b/deploy/crds/kustomize/kustomization.yaml
@@ -3,9 +3,9 @@ resources:
 
 # Use patches to add field validation that Kubebuilder markers can't
 patches:
-- path: patches.json
-  target:
-    group: apiextensions.k8s.io
-    version: v1
-    kind: CustomResourceDefinition
-    name: certificatepolicies.policy.open-cluster-management.io
+  - path: patches.json
+    target:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: certificatepolicies.policy.open-cluster-management.io

--- a/deploy/crds/kustomize/patches.json
+++ b/deploy/crds/kustomize/patches.json
@@ -1,23 +1,27 @@
 [
-    {
-        "op": "add",
-        "path": "/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/maximumCADuration/pattern",
-        "value": "^(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))+$"
-
-    },
-    {
-        "op": "add",
-        "path": "/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/maximumDuration/pattern",
-        "value": "^(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))+$"
-    },
-    {
-        "op": "add",
-        "path": "/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/minimumCADuration/pattern",
-        "value": "^(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))+$"
-    },
-    {
-        "op": "add",
-        "path": "/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/minimumDuration/pattern",
-        "value": "^(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))+$"
-    }
+  {
+    "op": "add",
+    "path": "/metadata/labels",
+    "value": { "policy.open-cluster-management.io/policy-type": "template" }
+  },
+  {
+    "op": "add",
+    "path": "/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/maximumCADuration/pattern",
+    "value": "^(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))+$"
+  },
+  {
+    "op": "add",
+    "path": "/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/maximumDuration/pattern",
+    "value": "^(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))+$"
+  },
+  {
+    "op": "add",
+    "path": "/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/minimumCADuration/pattern",
+    "value": "^(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))+$"
+  },
+  {
+    "op": "add",
+    "path": "/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/minimumDuration/pattern",
+    "value": "^(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))+$"
+  }
 ]

--- a/deploy/crds/policy.open-cluster-management.io_certificatepolicies.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_certificatepolicies.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
+  labels:
+    policy.open-cluster-management.io/policy-type: template
   name: certificatepolicies.policy.open-cluster-management.io
 spec:
   group: policy.open-cluster-management.io


### PR DESCRIPTION
This label is used to identify kinds that controllers should be monitoring for orphaned object cleanup.

ref: https://issues.redhat.com/browse/ACM-3049