### PR TITLE
[release-2.8](manual cherrypick) Hosted mode fix in cert-controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,7 @@ kind-deploy-controller-dev-normal: kind-deploy-controller
 .PHONY: kind-deploy-controller-dev-addon
 kind-deploy-controller-dev-addon:
 	kind load docker-image $(REGISTRY)/$(IMG):$(TAG) --name $(KIND_NAME)
-	kubectl annotate -n $(subst -hosted,,$(KIND_NAMESPACE)) --overwrite managedclusteraddon config-policy-controller\
+	kubectl annotate -n $(subst -hosted,,$(KIND_NAMESPACE)) --overwrite managedclusteraddon cert-policy-controller\
 		addon.open-cluster-management.io/values='{"args": {"frequency": 10}, "global":{"imagePullPolicy": "Never", "imageOverrides":{"cert_policy_controller": "$(REGISTRY)/$(IMG):$(TAG)"}}}'
 
 .PHONY: kind-create-cluster

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Go to the [Contributing guide](CONTRIBUTING.md) to learn how to get involved!
       ```
   - Deploy controller to a cluster
 
-    The controller is deployed to a namespace defined in `CONTROLLER_NAMESPACE` and monitors the namepace defined in `WATCH_NAMESPACE` for `CertificatePolicy` resources.
+    The controller is deployed to a namespace defined in `KIND_NAMESPACE and monitors the namepace defined in `WATCH_NAMESPACE` for `CertificatePolicy` resources.
 
     1. Create the deployment namespaces
        ```bash
@@ -81,7 +81,7 @@ Go to the [Contributing guide](CONTRIBUTING.md) to learn how to get involved!
        ```
        The deployment namespaces are configurable with:
        ```bash
-       export CONTROLLER_NAMESPACE=''  # (defaults to 'open-cluster-management-agent-addon')
+       export KIND_NAMESPACE=''  # (defaults to 'open-cluster-management-agent-addon')
        export WATCH_NAMESPACE=''       # (defaults to 'managed')
        ```
     2. Deploy the controller and related resources


### PR DESCRIPTION
Description: a reusable GitHub workflow for running the Kind E2E tests in hosted mode was added. We need to now gate fast-forwarding with these tests.

ref: https://issues.redhat.com/browse/ACM-5212