### PR TITLE
Create the event directly to allow error checking

### DIFF
--- a/main.go
+++ b/main.go
@@ -248,10 +248,13 @@ func main() {
 		)
 	}
 
+	instanceName, _ := os.Hostname() // on an error, instanceName will be empty, which is ok
+
 	r := &controllers.CertificatePolicyReconciler{
 		Client:          mgr.GetClient(),
 		Scheme:          mgr.GetScheme(),
 		Recorder:        mgr.GetEventRecorderFor("certificatepolicy-controller"),
+		InstanceName:    instanceName,
 		TargetK8sClient: targetK8sClient,
 		TargetK8sConfig: targetK8sConfig,
 	}


### PR DESCRIPTION
When we used the event APIs from controller runtime we got no error handling so there are some rare scenarios that seem to cause no event to be sent.  It is unknown exactly what those scenarios are.  This change creates the event directly so we can check for errors.

Refs:
 - https://issues.redhat.com/browse/ACM-8233