### PR TITLE
Ignore status updates in reconciles

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,10 +28,12 @@ import (
 	"open-cluster-management.io/addon-framework/pkg/lease"
 	extpolicyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	policyv1 "open-cluster-management.io/cert-policy-controller/api/v1"
 	controllers "open-cluster-management.io/cert-policy-controller/controllers"
@@ -266,7 +268,10 @@ func main() {
 		TargetK8sClient: targetK8sClient,
 		TargetK8sConfig: targetK8sConfig,
 	}
-	if err = r.SetupWithManager(mgr); err != nil {
+
+	if err = ctrl.NewControllerManagedBy(mgr).
+		For(&policyv1.CertificatePolicy{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Complete(r); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "CertificatePolicy")
 		os.Exit(1)
 	}


### PR DESCRIPTION
Reconciling a status update was clearing the policy status details which caused events to be sent on each loop.  This change ignores the status updates which I thought used to be ignored using a predicate function.  This may be a slightly different predicate function technique than what I thought we previously used.

Refs:
 - https://issues.redhat.com/browse/ACM-9355