### PR TITLE
Add compliant message for history

### DIFF
--- a/controllers/certificatepolicy_utils.go
+++ b/controllers/certificatepolicy_utils.go
@@ -113,6 +113,8 @@ func convertPolicyStatusToString(plc *policyv1.CertificatePolicy, defaultDuratio
 				}
 			}
 		}
+
+		return fmt.Sprintf(format, result, "All evaluated certificates are compliant")
 	}
 
 	return result


### PR DESCRIPTION
Cert-policy-controller doesn't write a message when it is compliant and has a namespace. Therefore it doesn't send compliance history. This PR will correct this issue. 

Ref: https://issues.redhat.com/browse/ACM-10146