### PR TITLE
Add vendoring step to Dockerfile.rhtap

### DIFF
--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -7,6 +7,7 @@ ENV COMPONENT=cert-policy-controller
 ENV REPO_PATH=/go/src/github.com/stolostron/${COMPONENT}
 WORKDIR ${REPO_PATH}
 COPY . .
+RUN go mod vendor
 RUN make build
 
 # Stage 2: Copy the binaries from the image builder to the base image


### PR DESCRIPTION
The build image expects it, and for some reason we had missed it in this repo.