### PR TITLE
Add ocm-polices namespace

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -70,7 +70,7 @@ var _ = BeforeSuite(func() {
 	clientManagedDynamic = NewKubeClientDynamic("", kubeconfigManaged, "")
 	defaultImageRegistry = "quay.io/open-cluster-management"
 	testNamespace = "managed"
-	testNamespaces := []string{testNamespace, "range1", "range2"}
+	testNamespaces := []string{testNamespace, "open-cluster-management-policies", "range1", "range2"}
 	defaultTimeoutSeconds = 90
 	By("Create Namespaces if needed")
 	namespaces := clientManaged.CoreV1().Namespaces()

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -26,6 +26,8 @@ func GetWithTimeout(
 	wantFound bool,
 	timeout int,
 ) *unstructured.Unstructured {
+	GinkgoHelper()
+
 	if timeout < 1 {
 		timeout = 1
 	}


### PR DESCRIPTION
Deploy policies to the same namespace on every managed cluster rather than dynamically determine the managed cluster namespace name for each cluster.(example: argoCD)
Ref: https://issues.redhat.com/browse/ACM-13609
Signed-off-by: yiraeChristineKim <yikim@redhat.com>