### PR TITLE
Use the actual expiration date rather than a relative time in status

### DIFF
--- a/api/v1/certificatepolicy_types.go
+++ b/api/v1/certificatepolicy_types.go
@@ -131,8 +131,7 @@ type Cert struct {
 	// Secret is the name of the secret containing the certificate.
 	Secret string `json:"secretName,omitempty"`
 
-	// Expiration is the string representation of the expiration of the certificate from the time of
-	// the report.
+	// Expiration is the string representation of the expiration date of the certificate in UTC RFC 3339 format.
 	Expiration string `json:"expiration,omitempty"`
 
 	// Expiry is the time.Duration representation of the expiration of the certificate from the time

--- a/deploy/crds/kustomize/policy.open-cluster-management.io_certificatepolicies.yaml
+++ b/deploy/crds/kustomize/policy.open-cluster-management.io_certificatepolicies.yaml
@@ -212,9 +212,9 @@ spec:
                             format: int64
                             type: integer
                           expiration:
-                            description: |-
-                              Expiration is the string representation of the expiration of the certificate from the time of
-                              the report.
+                            description: Expiration is the string representation of
+                              the expiration date of the certificate in UTC RFC 3339
+                              format.
                             type: string
                           expiry:
                             description: |-

--- a/deploy/crds/policy.open-cluster-management.io_certificatepolicies.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_certificatepolicies.yaml
@@ -217,9 +217,9 @@ spec:
                             format: int64
                             type: integer
                           expiration:
-                            description: |-
-                              Expiration is the string representation of the expiration of the certificate from the time of
-                              the report.
+                            description: Expiration is the string representation of
+                              the expiration date of the certificate in UTC RFC 3339
+                              format.
                             type: string
                           expiry:
                             description: |-

--- a/test/e2e/case1_expiration_test.go
+++ b/test/e2e/case1_expiration_test.go
@@ -157,12 +157,18 @@ var _ = DescribeTableSubtree("Test certificate policy expiration", Ordered, func
 	It("should create expired certificate on managed cluster", func() {
 		By("creating " + case1ExpiredCertificate + " on managed cluster")
 		utils.Kubectl("apply", "-f", case1ExpiredCertificate, "--kubeconfig", kubeconfigManaged)
+
+		var certPolicy *unstructured.Unstructured
+
 		Eventually(func() interface{} {
-			managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrCertPolicy,
+			certPolicy = utils.GetWithTimeout(clientManagedDynamic, gvrCertPolicy,
 				case1CertPolicyName, testNamespaceLocal, true, defaultTimeoutSeconds)
 
-			return utils.GetComplianceState(managedPlc)
+			return utils.GetComplianceState(certPolicy)
 		}, defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
+
+		msg, _, _ := unstructured.NestedString(certPolicy.Object, "status", "compliancyDetails", "default", "message")
+		Expect(msg).To(ContainSubstring("expired-cert expires on 2021-04-06T02:32:56Z"))
 	})
 	It("should become Compliant with unexpired certificate on managed cluster", func() {
 		utils.Kubectl("apply", "-f", case1UnexpiredCertificate, "--kubeconfig", kubeconfigManaged)


### PR DESCRIPTION
This also updates the status if the message changes.

Relates:
https://issues.redhat.com/browse/ACM-13736