### PR TITLE
[2.10 Manual Backport] Use the actual expiration date rather than a relative time in status

### DIFF
--- a/api/v1/certificatepolicy_types.go
+++ b/api/v1/certificatepolicy_types.go
@@ -123,7 +123,8 @@ type CompliancyDetails struct {
 
 // Cert contains its related secret and when it expires
 type Cert struct {
-	Secret     string        `json:"secretName,omitempty"`
+	Secret string `json:"secretName,omitempty"`
+	// Expiration is the string representation of the expiration date of the certificate in UTC RFC 3339 format.
 	Expiration string        `json:"expiration,omitempty"`
 	Expiry     time.Duration `json:"expiry,omitempty"`
 	CA         bool          `json:"ca,omitempty"`

--- a/controllers/certificatepolicy_controller.go
+++ b/controllers/certificatepolicy_controller.go
@@ -401,7 +401,7 @@ func parseCertificate(secret *corev1.Secret) (*policyv1.Cert, error) {
 
 	cert = policyv1.Cert{
 		Secret:     secret.Name,
-		Expiration: duration.String(),
+		Expiration: expiration.UTC().Format(time.RFC3339),
 		Expiry:     duration,
 		CA:         x509Cert.IsCA,
 		Duration:   maximumDuration,
@@ -523,7 +523,7 @@ func buildPolicyStatusMessage(list map[string]policyv1.Cert, count uint, namespa
 		for cert, certDetails := range list {
 			details := certDetails
 			if isCertificateExpiring(&details, policy) {
-				message = fmt.Sprintf("%s%s expires in %s\n", message, cert, details.Expiration)
+				message = fmt.Sprintf("%s%s expires on %s\n", message, cert, details.Expiration)
 			}
 
 			if isCertificateLongDuration(&details, policy) {
@@ -595,12 +595,11 @@ func addViolationCount(plc *policyv1.CertificatePolicy, message string, count ui
 	if count > 0 && plc.Status.ComplianceState == policyv1.Compliant {
 		changed = true
 	}
-	// The message contains the amount of time until expiration which changes each cycle
-	// Do not compare the message
-	//if msg != plc.Status.CompliancyDetails[namespace].Message {
-	//	klog.Infof("The policy %s has a new message: %s", plc.Name, msg)
-	//	changed = true
-	//}
+
+	if msg != plc.Status.CompliancyDetails[namespace].Message {
+		changed = true
+	}
+
 	if haveNewNonCompliantCertificate(plc, namespace, certificates) {
 		changed = true
 	}

--- a/deploy/crds/kustomize/policy.open-cluster-management.io_certificatepolicies.yaml
+++ b/deploy/crds/kustomize/policy.open-cluster-management.io_certificatepolicies.yaml
@@ -181,6 +181,9 @@ spec:
                             format: int64
                             type: integer
                           expiration:
+                            description: Expiration is the string representation of
+                              the expiration date of the certificate in UTC RFC 3339
+                              format.
                             type: string
                           expiry:
                             description: A Duration represents the elapsed time between

--- a/deploy/crds/policy.open-cluster-management.io_certificatepolicies.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_certificatepolicies.yaml
@@ -185,6 +185,9 @@ spec:
                             format: int64
                             type: integer
                           expiration:
+                            description: Expiration is the string representation of
+                              the expiration date of the certificate in UTC RFC 3339
+                              format.
                             type: string
                           expiry:
                             description: A Duration represents the elapsed time between


### PR DESCRIPTION
Backport of:
- #397 
- https://github.com/stolostron/cert-policy-controller/pull/396