### PR TITLE
Handle non-cert secrets better

### DIFF
--- a/controllers/certificatepolicy_controller_test.go
+++ b/controllers/certificatepolicy_controller_test.go
@@ -463,13 +463,11 @@ func TestParseCertificate(t *testing.T) {
 	)
 	assert.Len(t, secretList.Items, 1)
 
-	cert, err := parseCertificate(&secretList.Items[0])
-	assert.NoError(t, err)
+	cert := parseCertificate(&secretList.Items[0])
 	assert.NotNil(t, cert)
 
 	update, nonCompliant, list := r.checkSecrets(context.TODO(), instance, "default")
 
-	assert.NoError(t, err)
 	assert.Equal(t, uint(1), nonCompliant)
 	assert.True(t, update)
 
@@ -503,7 +501,6 @@ func TestParseCertificate(t *testing.T) {
 
 	update, nonCompliant, list = r.checkSecrets(context.TODO(), instance, "default")
 
-	assert.NoError(t, err)
 	assert.Equal(t, uint(2), nonCompliant)
 	assert.True(t, update)
 


### PR DESCRIPTION
Previously `parseCertificate` would ignore the error when it couldn't parse a possible certificate in a secret, but surface a new error when the secret didn't have a certificate in it. That error would then be logged, and in some environments could cause a major logging burden.

Now, if parsing fails the error is just logged (as it was before), but if the secret doesn't have a certificate, this is logged (at a debug level) and the secret is just skipped.

Refs:
 - https://issues.redhat.com/browse/ACM-23000