### PR TITLE
Add Dockerfile.art for ART/Brew build migration

### DIFF
--- a/build/Dockerfile.art
+++ b/build/Dockerfile.art
@@ -1,0 +1,45 @@
+ARG ACM_VERSION=${ACM_VERSION}
+
+# Copyright Contributors to the Open Cluster Management project
+
+# Stage 1: Use image builder to build the target binaries
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.25.8 AS builder
+
+ENV COMPONENT=cert-policy-controller
+ENV REPO_PATH=/go/src/github.com/stolostron/${COMPONENT}
+WORKDIR ${REPO_PATH}
+COPY . .
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime make build
+
+# Stage 2: Copy the binaries from the image builder to the base image
+FROM registry-proxy.engineering.redhat.com/ubi9/ubi-minimal:latest
+
+ARG ACM_VERSION
+
+ENV COMPONENT=cert-policy-controller
+ENV REPO_PATH=/go/src/github.com/stolostron/${COMPONENT}
+ENV OPERATOR=/usr/local/bin/${COMPONENT} \
+    USER_UID=1001 \
+    USER_NAME=${COMPONENT}
+
+# install operator binary
+COPY --from=builder ${REPO_PATH}/build/_output/bin/${COMPONENT} ${OPERATOR}
+
+COPY --from=builder ${REPO_PATH}/build/bin /usr/local/bin
+RUN  /usr/local/bin/user_setup
+
+RUN microdnf install -y shadow-utils procps
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+
+USER ${USER_UID}
+
+LABEL name="rhacm2/cert-policy-controller-rhel9"
+LABEL summary="Monitor certificates on the cluster"
+LABEL description="The CertificatePolicy kind compares the desired state of certificates with certificates on the cluster."
+LABEL io.k8s.display-name="CertificatePolicy controller"
+LABEL io.k8s.description="The CertificatePolicy kind compares the desired state of certificates with certificates on the cluster."
+LABEL com.redhat.component="acm-cert-policy-controller-container"
+LABEL io.openshift.tags="data,images"
+LABEL url="https://github.com/stolostron/cert-policy-controller"
+LABEL cpe="cpe:/a:redhat:acm:${ACM_VERSION}::el9"


### PR DESCRIPTION
HYPBLD-847: ACM 2.16: Create Dockerfile.art + ocp-build-data config
https://redhat.atlassian.net/browse/HYPBLD-847

Create the build configuration required for ART to build ACM 2.16 components.

Dockerfile.art files (50 repos):                                                                     
- Create Dockerfile.art in each ACM repo on release-2.16 branch                                      
- Use existing Dockerfile.rhtap as starting point                                                    
- Change registry to registry-proxy.engineering.redhat.com
- Add FIPS flags (GOEXPERIMENT=strictfipsruntime, CGO_ENABLED=1)                                     
Note: multiclusterhub-operator uses brew.registry — needs manual FROM line conversion              

Signed-off-by: Brian Smith (briansmi@redhat.com)