### PR TITLE
chore: upgrade to Go 1.26

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: builder
   namespace: stolostron
-  tag: go1.25-linux
+  tag: go1.26-linux

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,7 +3,7 @@ ARG ACM_VERSION=${ACM_VERSION}
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: Use image builder to build the target binaries
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 ENV COMPONENT=cert-policy-controller
 ENV REPO_PATH=/go/src/github.com/stolostron/${COMPONENT}

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -3,7 +3,7 @@ ARG ACM_VERSION=${ACM_VERSION}
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: Use image builder to build the target binaries
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 ENV COMPONENT=cert-policy-controller
 ENV REPO_PATH=/go/src/github.com/stolostron/${COMPONENT}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module open-cluster-management.io/cert-policy-controller
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/go-logr/zapr v1.3.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated the build and CI toolchain images to use Go 1.26 instead of Go 1.25.
  * Bumped the Go toolchain directive in the project configuration to Go 1.26.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->