### PR TITLE
Experiment: Test Red Hat Hardened core-runtime Image (release-acm-212)

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 RUN make build
 
 # Stage 2: Copy the binaries from the image builder to the base image
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/hi/core-runtime:latest-openssl-fips
 
 ENV COMPONENT=cert-policy-controller
 ENV REPO_PATH=/go/src/github.com/stolostron/${COMPONENT}


### PR DESCRIPTION
## Purpose
This is an **experimental PR** against the inactive **release-acm-212** application to test Red Hat's hardened images.

## Changes
- Switch runtime base image from `registry.access.redhat.com/ubi9/ubi-minimal:latest`
- To: `registry.access.redhat.com/hi/core-runtime:latest-openssl-fips` (Red Hat Hardened Image with FIPS OpenSSL)
- Modified file: `build/Dockerfile` (line 13 only)

## Details
**Component:** cert-policy-controller  
**Target Release:** release-2.12 (inactive)  
**Hardened Image:** core-runtime with FIPS-enabled OpenSSL

### Diff
```diff
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/hi/core-runtime:latest-openssl-fips
```

## Testing
- Target: Inactive release-acm-212 Konflux application
- Goal: Validate Konflux build success with hardened images
- Focus: FIPS compliance, runtime compatibility
- Reference: https://images.redhat.com/

## Notes
- This is for experimentation only
- Not intended for merge to active releases
- Monitoring Konflux build pipeline for compatibility
- Part of batch testing across multiple ACM 2.12 components
- Only changes the runtime base image, no other modifications

/hold
/cc @gparvin
