### PR TITLE
fix: add events.k8s.io permissions

### DIFF
--- a/controllers/certificatepolicy_controller.go
+++ b/controllers/certificatepolicy_controller.go
@@ -76,9 +76,9 @@ type CertificatePolicyReconciler struct {
 //+kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=certificatepolicies,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=certificatepolicies/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=certificatepolicies/finalizers,verbs=update
-//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
-//+kubebuilder:rbac:groups="",resources=namespaces,verbs=list
-//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list
+//+kubebuilder:rbac:groups=core;events.k8s.io,resources=events,verbs=create;patch
+//+kubebuilder:rbac:groups=core,resources=namespaces,verbs=list
+//+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list
 
 // Reconcile only runs on DeleteFunc since this controller is polling based.
 func (r *CertificatePolicyReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -24,6 +24,7 @@ rules:
   - delete
 - apiGroups:
   - ""
+  - events.k8s.io
   resources:
   - events
   verbs:
@@ -38,13 +39,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - namespaces
   verbs:
   - list
@@ -55,6 +49,14 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - policy.open-cluster-management.io
   resources:

--- a/deploy/rbac/leader_election_role.yaml
+++ b/deploy/rbac/leader_election_role.yaml
@@ -18,6 +18,7 @@ rules:
   - delete
 - apiGroups:
   - ""
+  - events.k8s.io
   resources:
   - events
   verbs:

--- a/deploy/rbac/role.yaml
+++ b/deploy/rbac/role.yaml
@@ -7,13 +7,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - namespaces
   verbs:
   - list
@@ -24,6 +17,14 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - policy.open-cluster-management.io
   resources:


### PR DESCRIPTION
Followup to:
- #813

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated RBAC permissions for Kubernetes Events to consistently support both the core API group and `events.k8s.io`, improving reliability when creating and patching Events.
  * Refined leader-election RBAC for Events to include `events.k8s.io` alongside the core group.
  * Kept (and aligned) required access for namespaces and secrets with the controller’s operational needs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->