### PR TITLE
chore: enable Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
       interval: cron
       cronjob: "0 7 * * MON#1"
       timezone: America/New_York
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 14
     groups:
       github-actions:
         patterns:
@@ -16,6 +20,10 @@ updates:
       interval: cron
       cronjob: "0 7 * * MON#1"
       timezone: America/New_York
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 14
     groups:
       gomod:
         patterns:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added waiting periods for automated dependency updates.
  * Update checks now pause for 7 days by default, with longer delays for major and minor version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->