### PR TITLE
chore: move to PQC base image

### DIFF
--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -12,7 +12,7 @@ COPY . .
 RUN make build
 
 # Stage 2: Copy the binaries from the image builder to the base image
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:latest
 
 ARG ACM_VERSION
 


### PR DESCRIPTION
ref: https://redhat.atlassian.net/browse/ACM-41560

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Stage 2 container build to use a post-quantum cryptography-enabled base image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->